### PR TITLE
Worker update

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:fullfunctional": "run-p test:functional",
     "cichecks": "yarn && run-p build lint test",
     "test:functional:skip": "echo 'Not running functional cases in Master' && exit 0",
-    "test:crossbrowser-e2e": "yarn playwright install && echo 'Installed Playwright' && MOCHAWESOME_REPORTFILENAME=crossbrowser codeceptjs run-workers 3 crossBrowser --grep \"@cross-browser\" --reporter mocha-multi && echo 'Cross browser tests completed'",
+    "test:crossbrowser-e2e": "yarn playwright install && echo 'Installed Playwright' && MOCHAWESOME_REPORTFILENAME=crossbrowser codeceptjs run-multiple crossBrowser --grep \"@cross-browser\" --reporter mocha-multi && echo 'Cross browser tests completed'",
     "test:crossbrowser": "./bin/run-crossbrowser-tests.sh",
     "test:local": "codeceptjs run-multiple parallel",
     "test:single": "MOCHAWESOME_REPORTFILENAME=functional codeceptjs run  --grep '@single' --reporter mocha-multi"


### PR DESCRIPTION
Rewriting tests to use run-multiple instead of threaded workers as this does not trigger a teardown in jenkins despite working locally - ensures the e2e's don't time out.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
