### PR TITLE
DTSSTCI-834

### DIFF
--- a/src/main/steps/common/page.njk
+++ b/src/main/steps/common/page.njk
@@ -28,7 +28,11 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{ serviceName }} - {{ title }} - {{ govUk }}
+  {% if sessionErrors and sessionErrors.length > 0 %}
+    Error: {{ serviceName }} - {{ title }} - {{ govUk }}
+  {% else %}
+    {{ serviceName }} - {{ title }} - {{ govUk }}
+  {% endif %}
 {% endblock %}
 
 {% block bodyStart %}


### PR DESCRIPTION
### Change description

An 'Error:' prefix should now be displayed in the browser tab title of any page in the application where an error is triggered.

### JIRA link

https://tools.hmcts.net/jira/browse/DTSSTCI-834